### PR TITLE
fix: Multiple versions of pnpm specified

### DIFF
--- a/.github/workflows/demo-gh-pages.yml
+++ b/.github/workflows/demo-gh-pages.yml
@@ -26,28 +26,28 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          
+        # with:
+        #   version: 10 # Version specified in the package.json file
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
-          
+
       - name: Install dependencies
         run: pnpm install
-        
+
       - name: Build
         run: pnpm build:demo
-        
+
       - name: Upload demo ready build files
         uses: actions/upload-artifact@v4
         with:
@@ -62,14 +62,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: demo-files
           path: ./dist
-        
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix error for build action:

```
Error: Multiple versions of pnpm specified:
    - version [10](https://github.com/franlopezm/countdown/actions/runs/12949634054/job/36120755524#step:3:11) in the GitHub Action config with the key "version"
    - version pnpm@10.0.0 in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```